### PR TITLE
Specify point explicitly

### DIFF
--- a/url-hint.el
+++ b/url-hint.el
@@ -111,7 +111,7 @@ overlay) is pressed."
       (goto-char start-bound)
       (while (and (re-search-forward url-hint-url-regexp end-bound t)
                   (not (invisible-p (point))))
-        (push (url-get-url-at-point) urls)))
+        (push (url-get-url-at-point (match-beginning 0)) urls)))
     (dolist (url (nreverse urls))
       (browse-url url))))
 


### PR DESCRIPTION
url-get-url-at-point returns nil when cursor is on end-of-buffer.

`google.com` isn't opened by `M-x url-hint-open-all-urls`. Because `url-get-url-at-point` returns nil when cursor is end-of-buffer(EOB). So this change specifies beginning of URL explicitly for avoiding this issue.

```
http://www.yahoo.com
http://www.google.com[EOB]
```

This issue is not occurred when using avy jump command.

